### PR TITLE
Styles clean up& [ch28346]style for disabled filters

### DIFF
--- a/src_ts/layout/etools-form-element-wrapper.ts
+++ b/src_ts/layout/etools-form-element-wrapper.ts
@@ -21,9 +21,6 @@ export class EtoolsFormElementWrapper extends LitElement {
           --paper-input-container-underline-focus: {
             display: none;
           }
-          --paper-input-container-underline-disabled: {
-            display: none;
-          }
           --paper-input-prefix: {
             margin-right: 5px;
             margin-top: -2px;

--- a/src_ts/layout/filters/etools-filters.ts
+++ b/src_ts/layout/filters/etools-filters.ts
@@ -243,6 +243,14 @@ export class EtoolsFilters extends LitElement {
     this.setDefaultLastSelectedValues();
     // language=HTML
     return html`
+      <style>
+        etools-dropdown[disabled] {
+          opacity: 60%;
+        }
+        etools-dropdown-multi[disabled] {
+          opacity: 60%;
+        }
+      </style>
       <div id="filters">${this.selectedFiltersTmpl(this.filters)}</div>
 
       <div id="filters-selector">

--- a/src_ts/styles/readonly-styles.ts
+++ b/src_ts/styles/readonly-styles.ts
@@ -5,6 +5,7 @@ export const ReadonlyStyles = html`<style>
   etools-dropdown-multi[readonly],
   datepicker-lite[readonly],
   paper-input[readonly],
+  paper-input-container[readonly],
   paper-textarea[readonly],
   etools-currency-amount-input[readonly] {
     --paper-input-container-underline: {
@@ -22,12 +23,12 @@ export const ReadonlyStyles = html`<style>
     }
     --paper-input-container: {
       pointer-events: none;
-      cusrsor: text;
+      cursor: default;
     }
     --paper-input-container-label: {
       pointer-events: none;
       color: var(--secondary-text-color, #737373);
-      cusrsor: text;
+      cursor: default;
     }
     --esmm-select-cursor: text;
     --esmm-external-wrapper: {
@@ -49,11 +50,11 @@ export const ReadonlyStyles = html`<style>
       display: none;
     }
     --paper-input-container: {
-      cusrsor: text;
+      cursor: default;
     }
     --paper-input-container-label: {
       color: var(--secondary-text-color, #737373);
-      cusrsor: text;
+      cursor: default;
     }
     --esmm-select-cursor: text;
     --esmm-external-wrapper: {

--- a/src_ts/styles/shared-styles-lit.ts
+++ b/src_ts/styles/shared-styles-lit.ts
@@ -48,7 +48,7 @@ export const sharedStylesContent = `
     margin: 0 12px;
     --paper-input-container-focus-color: var(--module-primary);
     --paper-input-container: {
-      color: var(--gray-50) !important;
+      
       font-size: 13px;
       opacity: 1 !important;
     }
@@ -57,10 +57,6 @@ export const sharedStylesContent = `
     }
     --paper-input-container-underline-focus: {
       display: none;
-    }
-    --paper-input-container-underline-disabled: {
-      display: block !important;
-      border-bottom: 1px dashed var(--gray-20) !important;
     }
   }
 


### PR DESCRIPTION
INFO:
- By Default the style for disabled is a dashed underline, color = ---secondary-text-color. So it doesn't have to be re-specified
- `--paper-input-container-underline-disabled` doesn't have to be specified when readonly
- By default , the color in the input is --primary-text-color, it doesn't have to be changed